### PR TITLE
fix: update a model with a already uploaded file field untouched.

### DIFF
--- a/ajax_upload/widgets.py
+++ b/ajax_upload/widgets.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.conf import settings
 from django.core.files import File
+from django.core.files.storage import DefaultStorage
 from django.core.urlresolvers import reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
@@ -43,6 +44,8 @@ class AjaxClearableFileInput(forms.ClearableFileInput):
             elif file_path.startswith(settings.MEDIA_URL):
                 # Strip and media url to determine the path relative to media root
                 relative_path = file_path[len(settings.MEDIA_URL):]
+                if not relative_path.startswith('ajax_uploads'):
+                    return None
                 try:
                     uploaded_file = UploadedFile.objects.get(file=relative_path)
                 except UploadedFile.DoesNotExist:


### PR DESCRIPTION
for example, a FileField has parameter such as upload_to='img'.

If you _newly upload_ a new file it will all be ok, because in the ajax post, the url of "ajax_uploads/some_uuid_filename.jpg" will be used.

But if you have already uploaded the file, and just want to updata other fields in the form,
the form will be initialized with "img/some_uuid_filename.jpg" for the file field.
and  the code:

<pre>
uploaded_file = UploadedFile.objects.get(file=relative_path)
</pre>

will failed, because all files in UploadedFile are in fact "ajax_uploads/some_uuid_filename.jpg"

A field not in the form of "ajax_uploads/some_uuid_filename.jpg" has no newly uploaded file, thus we should ignored it.
