### PR TITLE
Update urls.py for Django 1.6 compatibility

### DIFF
--- a/ajax_upload/urls.py
+++ b/ajax_upload/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls import patterns, url
+except ImportError:
+    from django.conf.urls.defaults import patterns, url
 
 
 urlpatterns = patterns('ajax_upload.views',


### PR DESCRIPTION
django.conf.urls.defaults was deprecated some time back.
