### PR TITLE
Add possibility to determine upload_directory

### DIFF
--- a/ajax_upload/models.py
+++ b/ajax_upload/models.py
@@ -1,12 +1,12 @@
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from ajax_upload.settings import FILE_FIELD_MAX_LENGTH
+from ajax_upload.settings import FILE_FIELD_MAX_LENGTH, UPLOAD_TO_DIRECTORY
 
 
 class UploadedFile(models.Model):
     creation_date = models.DateTimeField(_('creation date'), auto_now_add=True)
-    file = models.FileField(_('file'), max_length=FILE_FIELD_MAX_LENGTH, upload_to='ajax_uploads/')
+    file = models.FileField(_('file'), max_length=FILE_FIELD_MAX_LENGTH, upload_to=UPLOAD_TO_DIRECTORY)
 
     class Meta:
         ordering = ('id',)

--- a/ajax_upload/settings.py
+++ b/ajax_upload/settings.py
@@ -2,4 +2,4 @@ from django.conf import settings
 
 
 FILE_FIELD_MAX_LENGTH = getattr(settings, 'AJAX_UPLOAD_FILE_FIELD_MAX_LENGTH', 255)
-UPLOAD_TO_DIRECTORY = getattr(settings, 'AJAX_UPLOAD_FILE_TARGET_DIRECTORY', 'ajax_upload/')
+UPLOAD_TO_DIRECTORY = getattr(settings, 'AJAX_UPLOAD_FILE_TARGET_DIRECTORY', 'ajax_uploads/')

--- a/ajax_upload/settings.py
+++ b/ajax_upload/settings.py
@@ -2,3 +2,4 @@ from django.conf import settings
 
 
 FILE_FIELD_MAX_LENGTH = getattr(settings, 'AJAX_UPLOAD_FILE_FIELD_MAX_LENGTH', 255)
+UPLOAD_TO_DIRECTORY = getattr(settings, 'AJAX_UPLOAD_FILE_TARGET_DIRECTORY', 'ajax_upload/'

--- a/ajax_upload/settings.py
+++ b/ajax_upload/settings.py
@@ -2,4 +2,4 @@ from django.conf import settings
 
 
 FILE_FIELD_MAX_LENGTH = getattr(settings, 'AJAX_UPLOAD_FILE_FIELD_MAX_LENGTH', 255)
-UPLOAD_TO_DIRECTORY = getattr(settings, 'AJAX_UPLOAD_FILE_TARGET_DIRECTORY', 'ajax_upload/'
+UPLOAD_TO_DIRECTORY = getattr(settings, 'AJAX_UPLOAD_FILE_TARGET_DIRECTORY', 'ajax_upload/')


### PR DESCRIPTION
Instead of statically defining `ajax_uploads/` to be the upload directory, give the user an additional possibility to customize the upload_to-directory using a new setting called `AJAX_UPLOAD_FILE_TARGET_DIRECTORY`, which if not set defaults to `ajax_uploads/`